### PR TITLE
Features/worldpay

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,13 @@
 import braintree_service from './providers/braintree';
 import pci_proxy_service from './providers/pci_proxy';
 import stripe_service from './providers/stripe';
+import worldpay_service from './providers/worldpay'
 
 const SERVICES = {
   braintree_service,
   pci_proxy_service,
-  stripe_service
+  stripe_service,
+  worldpay_service
 }
 
 export function init(service, settings) {

--- a/src/providers/worldpay.js
+++ b/src/providers/worldpay.js
@@ -1,0 +1,178 @@
+let libraryPaths = [
+  'https://cdn.worldpay.com/v1/worldpay.js'
+];
+let form, submit, closeBTN, numberField, expDateField;
+let hostedFieldsInstance = null;
+let loadingInterval = null;
+let gatewaySettings = {};
+let isReady = false;
+let modal;
+const acceptedKeys = [48,49,50,51,52,53,54,55,56,57,8,9,13,37,38,39,40];
+const controlKeys = [8,9,13,37,38,39,40];
+
+function _injectLibraryScripts() {
+  libraryPaths.forEach((path) => {
+    _injectLibraryScript(path);
+  })
+}
+
+function _injectLibraryScript(path) {
+  let head = document.getElementsByTagName('head').item(0);
+  let script = document.createElement('script');
+  script.setAttribute('type', 'text/javascript');
+  script.setAttribute('src', path);
+  head.appendChild(script);
+}
+
+function _drawForm() {
+  const { postfix } = gatewaySettings;
+
+  let body = document.getElementsByTagName('body').item(0);
+  let div  = document.createElement('div');
+
+  div.innerHTML = `
+    <div class="multiple_card_tokenization__modal_overlay multiple_card_tokenization__modal_overlay__braintree" style="display: none;" id="modal_${postfix}">
+      <div class="multiple_card_tokenization__modal_window">
+        <div class="multiple_card_tokenization__demo-frame">
+          <form action="/" method="post" id="worldpay_card_form_${postfix}" >
+            <legend class="multiple_card_tokenization__form-legend">
+              Card Details
+              <button id="close-form-${postfix}" class="multiple_card_tokenization__close-button"></button>
+            </legend>
+
+            <div class="multiple_card_tokenization__field-container">
+              <label class="multiple_card_tokenization__hosted-fields--label" for="card-number_${postfix}">Cardholder Name</label>
+              <input type="text" id="card-holder_name_${postfix}" class="multiple_card_tokenization__hosted-field" data-worldpay="name"/>
+            </div>
+
+            <div class="multiple_card_tokenization__field-container">
+              <label class="multiple_card_tokenization__hosted-fields--label" for="card-number_${postfix}">Card Number</label>
+              <input type="text" id="card-number_${postfix}" class="multiple_card_tokenization__hosted-field" data-worldpay="number"/>
+            </div>
+
+            <div class="multiple_card_tokenization__field-container multiple_card_tokenization__field-container__half-field">
+              <label class="multiple_card_tokenization__hosted-fields--label" for="expiration-date_${postfix}">Expiration Month</label>
+              <input type="text" id="expiration-date_${postfix}" class="multiple_card_tokenization__hosted-field" data-worldpay="exp-month" />
+            </div>
+
+            <div class="multiple_card_tokenization__field-container multiple_card_tokenization__field-container__half-field">
+              <label class="multiple_card_tokenization__hosted-fields--label" for="expiration-date_${postfix}">Expiration Year</label>
+              <input type="text" id="expiration-date_${postfix}" class="multiple_card_tokenization__hosted-field" data-worldpay="exp-year" />
+            </div>
+
+            <div class="multiple_card_tokenization__field-container multiple_card_tokenization__field-container__half-field">
+              <label class="multiple_card_tokenization__hosted-fields--label" for="cvv_${postfix}">CVV</label>
+              <input type="text" id="cvv_${postfix}" class="multiple_card_tokenization__hosted-field" data-worldpay="cvc" />
+            </div>
+
+            <div class="multiple_card_tokenization__button-container">
+            <input type="submit" class="multiple_card_tokenization__button button--small button--green" value="Save Card Details" id="submit_${postfix}"/>
+            </div>
+          </form>
+        <div>
+      </div>
+    </div>
+  `;
+
+  body.appendChild(div);
+
+  modal = document.getElementById(`modal_${postfix}`);
+}
+
+function _checkLoading() {
+  if (window.Worldpay) {
+    isReady = true;
+    _initializeScripts();
+    clearInterval(loadingInterval);
+  }
+}
+
+function _initializeScripts() {
+  const { postfix, connection } = gatewaySettings;
+
+  form     = document.querySelector(`#worldpay_card_form_${postfix}`);
+  submit   = document.querySelector(`#submit_${postfix}`);
+  closeBTN = document.querySelector(`#close-form-${postfix}`);
+  numberField = document.querySelector(`#card-number_${postfix}`);
+  expDateField = document.querySelector(`#expiration-date_${postfix}`);
+
+  form.addEventListener('submit', onSubmit.bind(this), false);
+  closeBTN.addEventListener('click', hideForm.bind(this), false);
+  numberField.addEventListener('keydown', manageCardNumber.bind(this), false);
+
+  Worldpay.setClientKey(connection.client_key);
+  Worldpay.setReusable(true);
+}
+
+function onSubmit(event) {
+
+  event.preventDefault();
+
+  Worldpay.card.createToken(form, function (status, response) {
+    if (response.token != null ) {
+      if (gatewaySettings.onTokenize && typeof(gatewaySettings.onTokenize) === 'function') {
+        gatewaySettings.onTokenize(response.token, response.paymentMethod.maskedCardNumber.split(' ')[3]);
+      }
+    }
+  });
+}
+
+function showForm () {
+  modal.style.display = 'block';
+}
+
+function hideForm () {
+  modal.style.display = 'none';
+}
+
+function manageSlashAtExpirationDate (event) {
+  if (acceptedKeys.indexOf(event.keyCode) == -1) {
+    event.preventDefault();
+  } else if (controlKeys.indexOf(event.keyCode) != -1) {
+  } else {
+    if (event.target.value.length == 1) {
+      event.target.value = event.target.value + event.key + '/';
+      event.preventDefault();
+    }
+  }
+}
+
+function manageCardNumber (event) {
+  const amex_steps = [4,10];
+  const steps = [4,8,12];
+  const amex_length = 15;
+  const length = 16;
+  if (acceptedKeys.indexOf(event.keyCode) == -1) {
+    event.preventDefault();
+  } else if (controlKeys.indexOf(event.keyCode) != -1) {
+  } else {
+    let val = event.target.value.replace(/\s/ig, '');
+    let used_length = event.target.value[0] == '3' ? amex_length : length;
+    let used_steps = event.target.value[0] == '3' ? amex_steps : steps;
+
+    if (used_steps.indexOf(val.length + 1) != -1) {
+      event.target.value = event.target.value + event.key + ' ';
+      event.preventDefault();
+    }
+
+    if (used_length == val.length) {
+      event.preventDefault();
+    }
+  }
+}
+
+export default class {
+  constructor(settings) {
+    gatewaySettings = {
+      ...settings,
+      postfix: (new Date()).getTime()
+    };
+
+    _injectLibraryScripts();
+    _drawForm();
+    loadingInterval = setInterval(_checkLoading.bind(this), 100);
+  }
+
+  showForm = showForm
+  hideForm = hideForm
+}

--- a/src/providers/worldpay.js
+++ b/src/providers/worldpay.js
@@ -1,14 +1,10 @@
 let libraryPaths = [
   'https://cdn.worldpay.com/v1/worldpay.js'
 ];
-let form, submit, closeBTN, numberField, expDateField;
-let hostedFieldsInstance = null;
+let form, submit, token_button;
 let loadingInterval = null;
 let gatewaySettings = {};
 let isReady = false;
-let modal;
-const acceptedKeys = [48,49,50,51,52,53,54,55,56,57,8,9,13,37,38,39,40];
-const controlKeys = [8,9,13,37,38,39,40];
 
 function _injectLibraryScripts() {
   libraryPaths.forEach((path) => {
@@ -30,53 +26,13 @@ function _drawForm() {
   let body = document.getElementsByTagName('body').item(0);
   let div  = document.createElement('div');
 
-  div.innerHTML = `
-    <div class="multiple_card_tokenization__modal_overlay multiple_card_tokenization__modal_overlay__braintree" style="display: none;" id="modal_${postfix}">
-      <div class="multiple_card_tokenization__modal_window">
-        <div class="multiple_card_tokenization__demo-frame">
-          <form action="/" method="post" id="worldpay_card_form_${postfix}" >
-            <legend class="multiple_card_tokenization__form-legend">
-              Card Details
-              <button id="close-form-${postfix}" class="multiple_card_tokenization__close-button"></button>
-            </legend>
-
-            <div class="multiple_card_tokenization__field-container">
-              <label class="multiple_card_tokenization__hosted-fields--label" for="card-number_${postfix}">Cardholder Name</label>
-              <input type="text" id="card-holder_name_${postfix}" class="multiple_card_tokenization__hosted-field" data-worldpay="name"/>
-            </div>
-
-            <div class="multiple_card_tokenization__field-container">
-              <label class="multiple_card_tokenization__hosted-fields--label" for="card-number_${postfix}">Card Number</label>
-              <input type="text" id="card-number_${postfix}" class="multiple_card_tokenization__hosted-field" data-worldpay="number"/>
-            </div>
-
-            <div class="multiple_card_tokenization__field-container multiple_card_tokenization__field-container__half-field">
-              <label class="multiple_card_tokenization__hosted-fields--label" for="expiration-date_${postfix}">Expiration Month</label>
-              <input type="text" id="expiration-date_${postfix}" class="multiple_card_tokenization__hosted-field" data-worldpay="exp-month" />
-            </div>
-
-            <div class="multiple_card_tokenization__field-container multiple_card_tokenization__field-container__half-field">
-              <label class="multiple_card_tokenization__hosted-fields--label" for="expiration-date_${postfix}">Expiration Year</label>
-              <input type="text" id="expiration-date_${postfix}" class="multiple_card_tokenization__hosted-field" data-worldpay="exp-year" />
-            </div>
-
-            <div class="multiple_card_tokenization__field-container multiple_card_tokenization__field-container__half-field">
-              <label class="multiple_card_tokenization__hosted-fields--label" for="cvv_${postfix}">CVV</label>
-              <input type="text" id="cvv_${postfix}" class="multiple_card_tokenization__hosted-field" data-worldpay="cvc" />
-            </div>
-
-            <div class="multiple_card_tokenization__button-container">
-            <input type="submit" class="multiple_card_tokenization__button button--small button--green" value="Save Card Details" id="submit_${postfix}"/>
-            </div>
-          </form>
-        <div>
-      </div>
-    </div>
-  `;
-
   body.appendChild(div);
 
-  modal = document.getElementById(`modal_${postfix}`);
+  div.innerHTML = `
+    <form id="worldpay_card_form_${postfix}">
+      <div id='paymentSection'></div>
+    </form>
+  `
 }
 
 function _checkLoading() {
@@ -92,73 +48,40 @@ function _initializeScripts() {
 
   form     = document.querySelector(`#worldpay_card_form_${postfix}`);
   submit   = document.querySelector(`#submit_${postfix}`);
-  closeBTN = document.querySelector(`#close-form-${postfix}`);
-  numberField = document.querySelector(`#card-number_${postfix}`);
-  expDateField = document.querySelector(`#expiration-date_${postfix}`);
 
   form.addEventListener('submit', onSubmit.bind(this), false);
-  closeBTN.addEventListener('click', hideForm.bind(this), false);
-  numberField.addEventListener('keydown', manageCardNumber.bind(this), false);
 
-  Worldpay.setClientKey(connection.client_key);
-  Worldpay.setReusable(true);
-}
-
-function onSubmit(event) {
-
-  event.preventDefault();
-
-  Worldpay.card.createToken(form, function (status, response) {
-    if (response.token != null ) {
-      if (gatewaySettings.onTokenize && typeof(gatewaySettings.onTokenize) === 'function') {
-        gatewaySettings.onTokenize(response.token, response.paymentMethod.maskedCardNumber.split(' ')[3]);
+  Worldpay.useTemplateForm({
+    'clientKey': connection.client_key,
+    'form': `#worldpay_card_form_${postfix}`,
+    'paymentSection':'paymentSection',
+    'display': 'modal',
+    'reusable': true,
+    'callback': function(response) {
+      if (response && response.token) {
+        if (gatewaySettings.onTokenize && typeof(gatewaySettings.onTokenize) === 'function') {
+          gatewaySettings.onTokenize(response.token, response.paymentMethod.maskedCardNumber.split(' ')[3]);
+          Worldpay.closeTemplateModal();
+        }
       }
     }
   });
+
+  token_button = document.getElementById('token_container-button');
+  token_button.style.display = 'none';
+}
+
+function onSubmit(event) {
+  event.preventDefault();
+  Worldpay.submitTemplateForm();
 }
 
 function showForm () {
-  modal.style.display = 'block';
+  Worldpay.getTemplateToken();
 }
 
 function hideForm () {
-  modal.style.display = 'none';
-}
-
-function manageSlashAtExpirationDate (event) {
-  if (acceptedKeys.indexOf(event.keyCode) == -1) {
-    event.preventDefault();
-  } else if (controlKeys.indexOf(event.keyCode) != -1) {
-  } else {
-    if (event.target.value.length == 1) {
-      event.target.value = event.target.value + event.key + '/';
-      event.preventDefault();
-    }
-  }
-}
-
-function manageCardNumber (event) {
-  const amex_steps = [4,10];
-  const steps = [4,8,12];
-  const amex_length = 15;
-  const length = 16;
-  if (acceptedKeys.indexOf(event.keyCode) == -1) {
-    event.preventDefault();
-  } else if (controlKeys.indexOf(event.keyCode) != -1) {
-  } else {
-    let val = event.target.value.replace(/\s/ig, '');
-    let used_length = event.target.value[0] == '3' ? amex_length : length;
-    let used_steps = event.target.value[0] == '3' ? amex_steps : steps;
-
-    if (used_steps.indexOf(val.length + 1) != -1) {
-      event.target.value = event.target.value + event.key + ' ';
-      event.preventDefault();
-    }
-
-    if (used_length == val.length) {
-      event.preventDefault();
-    }
-  }
+  Worldpay.closeTemplateModal();
 }
 
 export default class {

--- a/src/providers/worldpay.js
+++ b/src/providers/worldpay.js
@@ -52,7 +52,7 @@ function _initializeScripts() {
   form.addEventListener('submit', onSubmit.bind(this), false);
 
   Worldpay.useTemplateForm({
-    'clientKey': connection,
+    'clientKey': connection.client_key,
     'form': `#worldpay_card_form_${postfix}`,
     'paymentSection':'paymentSection',
     'display': 'modal',

--- a/src/providers/worldpay.js
+++ b/src/providers/worldpay.js
@@ -52,7 +52,7 @@ function _initializeScripts() {
   form.addEventListener('submit', onSubmit.bind(this), false);
 
   Worldpay.useTemplateForm({
-    'clientKey': connection.client_key,
+    'clientKey': connection,
     'form': `#worldpay_card_form_${postfix}`,
     'paymentSection':'paymentSection',
     'display': 'modal',


### PR DESCRIPTION
Add Worldpay integration using default template form. 
Card validation provides by Worldpay library.
By default,  if we use  useTemplateForm() method, Worldpay adds button on the page,
clicking on this button shows modal with card information. 
My implementation shows modal immediately when calling showForm() method.

Settings: 
To make it work we provide settings object:
`{connection: 
    {client_key: 'your_client_key'}
}`